### PR TITLE
Update rfc-meta.md

### DIFF
--- a/proposed/rfc-meta.md
+++ b/proposed/rfc-meta.md
@@ -44,8 +44,8 @@ As a single point of truth, all proposals are managed in this repository
 
 In the `template/` directory of the repository, templates for the proposals are 
 provided, so they will follow a certain structure. Having this structure allows 
-to build user interfaces for users who are not familiar with GitHub, f.x. on the 
-[Ideas portal][ideas].
+to build user interfaces for users who are not familiar with GitHub, f.x. on a 
+new version of the Ideas portal.
 
 To get started, the two first paragraphs are most important:
 * **1. Summary** to describe what the proposal is about, and
@@ -134,7 +134,6 @@ _**Note:** Order descending chronologically._
 
 
 [PHP FIG]: http://www.php-fig.org/
-[ideas]: https://ideas.joomla.org
 [rfc-workflow]: rfc-workflow.md
 [rfc-voting]: rfc-voting.md
 

--- a/proposed/rfc-meta.md
+++ b/proposed/rfc-meta.md
@@ -129,7 +129,6 @@ The voting process is described in detail in a separate [Voting Document][rfc-vo
 _**Note:** Order descending chronologically._
 
 * [PHP FIG][]
-* [Ideas portal][ideas]
 * [Workflow Document][rfc-workflow]
 * [Voting Document][rfc-voting]
 


### PR DESCRIPTION
Remove Ideas Portal.
That one is not used anymore and will probably be removed.
Maybe it will come back in a different way, but is not on the current action list for 2020 within Webmasters group.