### PR TITLE
feat(open-voting): Open voting to all volunteers

### DIFF
--- a/bylaws/voting.md
+++ b/bylaws/voting.md
@@ -1,8 +1,8 @@
 # Voting Protocol
 
-1. Only Production Department Team Leaders and the Production Department Coordinator may initiate a call for votes on a measure.
-2. Only Production Department Team Leaders and the Production Department Coordinator may vote on a measure.
-3. The time limit on a vote is 14 days from the time of the call for votes, or until all voting members have cast their vote, whichever comes first. Votes cast after the time limit are not valid.
+1. Once an RFC is on Review for 7 days, a call for votes on a measure will be issued.
+2. All active volunteers may vote on an RFC proposal.
+3. The time limit on a vote is 7 days from the time of the call for votes, or until all voting members have cast their vote, whichever comes first. Votes cast after the time limit are not valid.
 4. Votes can be +1 (“in favor”), -1 (“against”), or 0 (“abstain”).
 5. One-third or more of the voting members must vote within the time limit for the vote to be valid. This is the equivalent of establishing a quorum. For example:
   > - If there are 20, 21, or 22 members, then 7 or more must vote within the


### PR DESCRIPTION
The RFC Proposal Process is much better than what we do today. It a clear and defined process. So, I'm ok to implement it as soon as possible.

Given say that... it still has a lot of "Only Production Department Team..." I think that Production is not the owner of the "Product". 

Production is responsible for the development, but not the owner; so they shouldn't be the only area responsible for the final decisions.

My question is: why would I write an RFC knowing that Production is not going to vote for it?

In my view, everyone involved in the product definition must be allowed to vote.

Let's say that someone creates an RFC to migrate Joomla to Python .... it is a crazy proposal, but if it can be redacted by an Editor, Sponsor and three other individuals; then a vote must be done, a kind of right of "free speech".

If we are defining a **neutral RFC process**, it must be a fully administrative process. When a vote is due, then it is called. 

Otherwise, the new features are always limited by the views of the Production department and there is no voice to other views.